### PR TITLE
多线程并发bug修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+### 2.1.1-alpha(Apr 23,2021)
+  * [bug fix] 修复多线程reequest函数bug:responseParseWithResBody和requestWithResponseAndBody函数
+  * [bug fix] 修复异步分片上传的bug
+  * [bug fix] 修复genBucketURL的多线程bug
+
+
+### 2.1.0-alpha(Oct 16,2020)
+  * [new feature] 添加客户端加密功能

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 > Modules are interface and implementation.  
 > The best modules are where interface is much simpler than implementation.  
 > **By: John Ousterhout**
+>
+> [US3文档中心 Go-SDK](https://ucloud-us3.github.io/go-sdk/%E6%A6%82%E8%BF%B0.html)
 
 Table of Contents
 =================

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 > Modules are interface and implementation.  
 > The best modules are where interface is much simpler than implementation.  
 > **By: John Ousterhout**
->
-> [US3文档中心 Go-SDK](https://ucloud-us3.github.io/go-sdk/%E6%A6%82%E8%BF%B0.html)
 
 Table of Contents
 =================
@@ -605,4 +603,5 @@ if err != nil {
 
 > - UCloud US3 [官方网站](https://www.ucloud.cn/site/product/ufile.html)
 > - UCloud US3 [官方文档中心](https://docs.ucloud.cn/ufile/README)
+> - UCloud US3 [开发者文档](https://ucloud-us3.github.io/go-sdk/概述.html)
 > - UCloud 官方技术支持：[提交工单](https://accountv2.ucloud.cn/work_ticket/create)

--- a/bucket.go
+++ b/bucket.go
@@ -166,11 +166,11 @@ func (u *UFileRequest) bucketRequest(query url.Values, data response) error {
 	if err != nil {
 		return err
 	}
-	err = u.responseParse(resp)
+	resBody, err := u.responseParseWithResBody(resp)
 	if err != nil {
 		return err
 	}
-	err = json.Unmarshal(u.LastResponseBody, data)
+	err = json.Unmarshal(resBody, data)
 	if err != nil {
 		return err
 	}
@@ -178,6 +178,5 @@ func (u *UFileRequest) bucketRequest(query url.Values, data response) error {
 }
 
 func (u *UFileRequest) genBucketURL(query url.Values) string {
-	u.baseURL.RawQuery = u.Auth.AuthorizationBucketMgr(query)
-	return u.baseURL.String()
+	return u.baseURL.String() + "?" + u.Auth.AuthorizationBucketMgr(query)
 }

--- a/example/demo_iop.go
+++ b/example/demo_iop.go
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	localUpFile        = "./stream-up.png"
-	localDlFile        = "./stream-dl.png"
-	iopConfigFile      = "./config.json"
-	iopRemoteFileKey   = "picture.png"
+	localUpFile      = "./stream-up.png"
+	localDlFile      = "./stream-dl.png"
+	iopConfigFile    = "./config.json"
+	iopRemoteFileKey = "picture.png"
 )
 
 func main() {
@@ -25,6 +25,10 @@ func main() {
 	if err != nil {
 		panic(err.Error())
 	}
+
+	if _, err := os.Stat(localUpFile); os.IsNotExist(err) {
+		panic(err.Error())
+	}
 	log.Println("正在上传文件...")
 
 	//构建iop命令，缩放为原图50%
@@ -36,7 +40,6 @@ func main() {
 	} else {
 		log.Println("iop上传文件成功")
 	}
-
 
 	log.Println("正在下载文件...")
 	file, err := os.OpenFile(localDlFile, os.O_CREATE|os.O_WRONLY, 0755)

--- a/request.go
+++ b/request.go
@@ -160,7 +160,7 @@ func (u *UFileRequest) request(req *http.Request) error {
 }
 
 func (u *UFileRequest) requestWithResp(req *http.Request) (resp *http.Response, err error) {
-	req.Header.Set("User-Agent", "UFileGoSDK/2.02")
+	req.Header.Set("User-Agent", "UFileGoSDK/2.1.1")
 
 	resp, err = u.Client.Do(req.WithContext(u.Context))
 	// If we got an error, and the context has been canceled,


### PR DESCRIPTION

1. 修复多线程reequest函数bug:
增加responseParseWithResBody和requestWithResponseAndBody函数
2. 修复异步分片上传的bug
3. 修复genBucketURL的多线程bug